### PR TITLE
Enhance logic in entrypoint.sh script

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,8 +29,14 @@ echo curl -LJO https://github.com/${repository}/archive/${ref}.tar.gz
 curl -LJO https://github.com/${repository}/archive/${ref}.tar.gz
 
 # check that files were downloaded correctly and match expected name
-[ -s ${dl_filename}.zip ] || (echo ERROR: Could not get zip file && exit 1)
-[ -s ${dl_filename}.tar.gz ] || (echo ERROR: Could not get tar.gz file && exit 1)
+if [ ! -s ${dl_filename}.zip ]; then
+    echo "ERROR: Could not get zip file: ${dl_filename}.zip"
+    exit 1
+fi
+if [ ! -s ${dl_filename}.tar.gz ]; then
+    echo "ERROR: Could not get tar.gz file: ${dl_filename}.tar.gz"
+    exit 1
+fi
 
 # create checksum from both files
 echo Creating $cs_zip_filename with checksums for ZIP file

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ repository=${GITHUB_REPOSITORY}
 ref=${GITHUB_REF}
 tag=`basename ${ref}`
 event_name=${GITHUB_EVENT_NAME}
-dl_filename=`basename ${repository}`-${tag}
+dl_filename=`basename ${repository}`-`echo ${tag} | sed -r 's/^v//g'`
 cs_tar_filename=checksum_tar.txt
 cs_zip_filename=checksum_zip.txt
 


### PR DESCRIPTION
Propose updated logic to the entrypoint.sh script for 2 reasons:
1. Update syntax so that when the expected file name doesn't exist, the script actually returns bad status.
2. Modify logic for determining the expected release filename by removing the leading 'v' from the tag name.

I tested this with releases in METcalcpy. This release in particular works as expected:
https://github.com/dtcenter/METcalcpy/releases/tag/v9.9.9

Once this PR is approved, I'll delete that METcalcpy test release. And then I'll retag v1 in this repository.